### PR TITLE
fix(assets-build): 修复生产环境静态资源没有携带publicPath，导致资源404的问题

### DIFF
--- a/.umirc.ts
+++ b/.umirc.ts
@@ -1,10 +1,15 @@
 import { defineConfig } from 'dumi';
+
+const isProd = process.env.node_env === 'production';
+
+const nameSpace = '/toy-ui/';
+
 export default defineConfig({
   title: 'toy-ui',
-  favicon: '/assets/favicon.ico',
-  logo: '/assets/logo.png',
+  favicon: isProd ? `${nameSpace}assets/favicon.ico` : '/assets/favicon.ico',
+  logo: isProd ? `${nameSpace}assets/logo.png` : '/assets/logo.png',
   outputPath: 'docs-dist',
-  publicPath: '/toy-ui/',
-  base: '/toy-ui/',
+  publicPath: nameSpace,
+  base: nameSpace,
   // more config: https://d.umijs.org/config
 });


### PR DESCRIPTION
修复生产环境静态资源没有携带publicPath，导致资源404的问题

fix #1